### PR TITLE
appbarコンポーネントの各画面への適用、main.dartを初期画面がpurchase_listになるように変更

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+
+PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+
+COCOAPODS: 1.16.1

--- a/lib/core/components/app_bar/app_bar.dart
+++ b/lib/core/components/app_bar/app_bar.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
-class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
-  const PreferredSize({
+class CustomPreferredSize extends StatelessWidget
+    implements PreferredSizeWidget {
+  const CustomPreferredSize({
     super.key,
     required this.child,
     required this.preferredSize,

--- a/lib/core/components/app_bar/app_bar.dart
+++ b/lib/core/components/app_bar/app_bar.dart
@@ -17,8 +17,8 @@ class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
 }
 
 class AppBarComponent extends StatelessWidget implements PreferredSizeWidget {
-  AppBarComponent({required this.title, super.key});
-  String title;
+  const AppBarComponent({required this.title, super.key});
+  final String title;
 
   @override
   Size get preferredSize {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,6 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: AppBarComponent(title: '購入前ページ'));
+    return const Scaffold(appBar: AppBarComponent(title: '購入前ページ'));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:kakubo/core/components/app_bar/app_bar.dart';
+// import 'package:kakubo/core/components/app_bar/app_bar.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:kakubo/core/datasources/models/items.dart';
+import 'package:kakubo/screens/purchase_list.dart';
 import 'package:path_provider/path_provider.dart';
 
 late Box box;
@@ -26,23 +27,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'KAKUBO'),
+      home: PurchaseList(),
     );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(appBar: AppBarComponent(title: '購入前ページ'));
   }
 }

--- a/lib/screens/purchase_list.dart
+++ b/lib/screens/purchase_list.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:kakubo/core/components/app_bar/app_bar.dart';
+
+// 下の青線に詳細は書くけど、この青線は「main.dartの呼び出し元にconstつけろ」やけど無視でok
+class PurchaseList extends StatefulWidget {
+  @override
+  State<PurchaseList> createState() => _PurchaseListState();
+}
+
+class _PurchaseListState extends State<PurchaseList> {
+  @override
+  Widget build(BuildContext context) {
+    // 下の青線は「constつけろ」やけど、つけるとタイトル変えられなくなってコンポーネント化の意味無くなるから無視でok
+    return Scaffold(appBar: AppBarComponent(title: '購入品リスト'));
+  }
+}

--- a/lib/screens/regret_list.dart
+++ b/lib/screens/regret_list.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:kakubo/core/components/app_bar/app_bar.dart';
+
+// 下の青線に詳細は書くけど、この青線は「呼び出し元にconstつけろ」やけど無視でok
+class RegretList extends StatefulWidget {
+  @override
+  State<RegretList> createState() => _RegretListState();
+}
+
+class _RegretListState extends State<RegretList> {
+  @override
+  Widget build(BuildContext context) {
+    // 下の青線は「constつけろ」やけど、つけるとタイトル変えられなくなってコンポーネント化の意味無くなるから無視でok
+    return Scaffold(appBar: AppBarComponent(title: '購入品リスト'));
+  }
+}

--- a/lib/screens/unrated_list.dart
+++ b/lib/screens/unrated_list.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:kakubo/core/components/app_bar/app_bar.dart';
+
+// 下の青線に詳細は書くけど、この青線は「呼び出し元にconstつけろ」やけど無視でok
+class UnratedList extends StatefulWidget {
+  @override
+  State<UnratedList> createState() => _UnratedListState();
+}
+
+class _UnratedListState extends State<UnratedList> {
+  @override
+  Widget build(BuildContext context) {
+    // 下の青線は「constつけろ」やけど、つけるとタイトル変えられなくなってコンポーネント化の意味無くなるから無視でok
+    return Scaffold(appBar: AppBarComponent(title: '購入品リスト'));
+  }
+}


### PR DESCRIPTION
初期画面設定に手こずってappbarのuiは触れられへんかった🙏 
それぞれの画面の土台はできたので、buildメソッド内のbody:にそれぞれのコンポーネント埋め込んでく流れでいきやしょ！
全員最新で開発始めていきたいので、二人がレビューあげたの確認してから私がmargeします