### PR TITLE
hiveデータベースに入力情報を保存する機能を追加

### DIFF
--- a/lib/features/input/entries/input.dart
+++ b/lib/features/input/entries/input.dart
@@ -22,15 +22,12 @@ class _InputItemsState extends State<InputItems> {
   void addList() {
     final String itemName = itemController.text;
     final int itemPrice = int.parse(priceController.text);
-
     final newItem = Items(
       item: itemName,
       price: itemPrice,
     );
-
     final box = Hive.box('box');
     box.add(newItem);
-
     print('商品名: $itemName');
     print('金額: $itemPrice');
   }

--- a/lib/features/input/entries/input.dart
+++ b/lib/features/input/entries/input.dart
@@ -37,9 +37,7 @@ class _InputItemsState extends State<InputItems> {
 
   void submition() {
     if (_formKey.currentState?.validate() ?? false) {
-      // 入力が正しければ、データを使用する処理
-      print('商品名: ${itemController.text}');
-      print('金額: ${priceController.text}');
+      addList();
       Navigator.pop(context); // 入力フォームを閉じる
     }
   }

--- a/lib/features/input/entries/input.dart
+++ b/lib/features/input/entries/input.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:kakubo/core/datasources/models/items.dart';
 
 class InputItems extends StatefulWidget {
   const InputItems({super.key});
@@ -16,6 +18,22 @@ class _InputItemsState extends State<InputItems> {
 
   // フォームのキー　validatorでtextfieldが空とかnullの時の処理が記述可能
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  void addList() {
+    final String itemName = itemController.text;
+    final int itemPrice = int.parse(priceController.text);
+
+    final newItem = Items(
+      item: itemName,
+      price: itemPrice,
+    );
+
+    final box = Hive.box('box');
+    box.add(newItem);
+
+    print('商品名: $itemName');
+    print('金額: $itemPrice');
+  }
 
   void submition() {
     if (_formKey.currentState?.validate() ?? false) {


### PR DESCRIPTION
DBに入力情報を保存できるように改善しました。修正箇所は添付した画像の箇所です。
エラー処理で、金額の欄に数字以外のものが入力された場合には対応していません。必要があれば実装します。
確認をお願いします。

<img width="1512" alt="スクリーンショット 2024-11-09 16 50 48" src="https://github.com/user-attachments/assets/39c49524-21ff-4112-a3fe-cc393d80bb18">
